### PR TITLE
Get Out Side

### DIFF
--- a/@twc_config_compatibility/addons/twc_gearFixes/Helicopters.hpp
+++ b/@twc_config_compatibility/addons/twc_gearFixes/Helicopters.hpp
@@ -1,0 +1,17 @@
+class Heli_light_03_base_F;
+class UK3CB_BAF_Wildcat_Base: Heli_light_03_base_F {
+	TWC_getOut = 1;
+};
+
+class Helicopter_Base_H;
+class CUP_SA330_Base: Helicopter_Base_H {
+	TWC_getOut = 1;
+};
+
+class CUP_CH47F_base: Helicopter_Base_H {
+	backRotorForceCoef = 0.9;
+	cyclicForwardForceCoef = 1.5;
+	cyclicAsideForceCoef = 1.3;
+	bodyFrictionCoef = 1.4;
+	armorStructural = 20;
+};

--- a/@twc_config_compatibility/addons/twc_gearFixes/config.cpp
+++ b/@twc_config_compatibility/addons/twc_gearFixes/config.cpp
@@ -1197,15 +1197,7 @@ class CfgVehicles {
 		};
 	};
 	
-	class Helicopter_Base_H;
-	class CUP_CH47F_base: Helicopter_Base_H
-	{
-		backRotorForceCoef = 0.9;
-		cyclicForwardForceCoef = 1.5;
-		cyclicAsideForceCoef = 1.3;
-		bodyFrictionCoef = 1.4;
-		armorStructural = 20;
-	};
+	#include "Helicopters.hpp"
 	
 //handling modifications
 	class Car;

--- a/@twc_framework/addons/twc_core/CfgFunctions.hpp
+++ b/@twc_framework/addons/twc_core/CfgFunctions.hpp
@@ -10,6 +10,8 @@ class CfgFunctions {
 			/** MISC FUNCTIONALITY **/
 			class soundLoop {};
 			class setDirFly {};
+			class canGetOutSide {};
+			class getOutSide {};
 			
 			/** PLAYER RELATED **/
 			class isMember {};

--- a/@twc_framework/addons/twc_core/CfgVehicles.hpp
+++ b/@twc_framework/addons/twc_core/CfgVehicles.hpp
@@ -1,6 +1,6 @@
 class CfgVehicles {
+	// TODO: Add UI element for this, at some point
 	class Man;
-
 	class CAManBase: Man {
 		class ACE_Actions {
 			class ACE_MainActions {
@@ -10,6 +10,24 @@ class CfgVehicles {
 					statement = "[_player, _target] call TWC_Core_fnc_addToGroup";
 					exceptions[] = {"isNotSwimming"};
 				};
+			};
+		};
+	};
+	
+	// TODO: Add UI element for this, at some point
+	class Air;
+	class Helicopter: Air {
+		class ACE_SelfActions {
+			class TWC_GetOut_Left {
+				displayName = "Get Out Left";
+				condition = "_this call TWC_Core_fnc_canGetOutSide";
+				condition = "[_this] call TWC_Core_fnc_getOutSide";
+			};
+			
+			class TWC_GetOut_Right {
+				displayName = "Get Out Right";
+				condition = "_this call TWC_Core_fnc_canGetOutSide";
+				condition = "[_this, 'right'] call TWC_Core_fnc_getOutSide";
 			};
 		};
 	};

--- a/@twc_framework/addons/twc_core/functions/fn_canGetOutSide.sqf
+++ b/@twc_framework/addons/twc_core/functions/fn_canGetOutSide.sqf
@@ -1,0 +1,13 @@
+params ["_caller", "_vehicle"];
+
+_cachedResult = _vehicle getVariable ["TWC_canGetOut_cached", nil];
+
+if (isNil "_cachedResult") then {
+	_canBail = [(configFile >> "CfgVehicles" >> typeOf (_vehicle)), "TWC_getOut", 0] call BIS_fnc_returnConfigEntry;
+	_vehicle setVariable ["TWC_canGetOut_cached", _canBail, true];
+} else {
+	_canBail = _cachedResult;
+};
+
+if (_canBail == 0) exitWith { false };
+true;

--- a/@twc_framework/addons/twc_core/functions/fn_getOutSide.sqf
+++ b/@twc_framework/addons/twc_core/functions/fn_getOutSide.sqf
@@ -1,0 +1,26 @@
+params ["_args", ["_side", "left"]];
+
+private _unit = _args select 1;
+private _parent = objectParent _unit;
+
+private _bbr = boundingBoxReal _parent;
+private _width = abs((_bbr select 0 select 0) - (_bbr select 1 select 0)) + 0.1;
+private _pos = getPos _parent;
+private _dirvic = getDir _parent;
+
+moveOut _unit;
+unassignVehicle _unit;
+
+switch (_side) do {
+	case "right" : {
+		private _movedir = _dirvic + 90;
+		_unit setDir _movedir;
+		_unit setpos (_pos vectorAdd [0.5 * _width * sin (_movedir), 0.5 * _width * cos (_movedir), 0]);
+	};
+	
+	case "left" : {
+		private _movedir = _dirvic + -90;
+		_unit setDir _movedir;
+		_unit setpos (_pos vectorAdd [0.5 * _width * sin (_movedir), 0.5 * _width * cos (_movedir), 0]);
+	};
+};


### PR DESCRIPTION
Adds an ACE interaction to get out on a side of a medium lift helicopter. Currently added to the Wildcat and Puma, Lynx and in the future Wessex will also be needed.