### PR TITLE
AI control gestures

### DIFF
--- a/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
@@ -1,0 +1,13 @@
+class CfgFunctions {
+	class TWC_AI_Control_Gestures {
+		class functions {
+			file = "twc_ai_control_gestures\functions";
+			
+			/** Init on HC & Server **/
+			class init {};
+			
+			class signalAdvance {};
+			class signalHalt {};
+		};
+	};
+};

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
@@ -3,8 +3,9 @@ class CfgFunctions {
 		class functions {
 			file = "twc_ai_control_gestures\functions";
 			
-			/** Init on HC & Server **/
+			/** Init **/
 			class init {};
+			class clientPreInit {};
 			
 			class signalAdvance {};
 			class signalHalt {};

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
@@ -9,6 +9,8 @@ class CfgFunctions {
 			
 			class signalAdvance {};
 			class signalHalt {};
+			
+			class presenceCheckLoop {};
 		};
 	};
 };

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgFunctions.hpp
@@ -11,6 +11,10 @@ class CfgFunctions {
 			class signalHalt {};
 			
 			class presenceCheckLoop {};
+			
+			/** Modules **/
+			class moduleMissionIgnoreGestures {};
+			class moduleSetHaltIgnoreChance {};
 		};
 	};
 };

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
@@ -1,0 +1,30 @@
+class CfgVehicles {
+	class Man;
+
+	class CAManBase: Man {
+		class ACE_SelfActions {
+			class TWC_Gestures {
+				displayName = "Issue Order";
+				condition = "(canStand _target)";
+				statement = "";
+				exceptions[] = {"isNotSwimming"};
+				showDisabled = 1;
+				icon = "";
+				
+				class TWC_AI_Control_Gesture_Advance {
+					displayName = "Advance";
+					condition = "true";
+					statement = "[_target] call TWC_AI_Control_Gestures_fnc_signalAdvance";
+					showDisabled = 1;
+				};
+				
+				class TWC_AI_Control_Gesture_Halt {
+					displayName = "Halt";
+					condition = "true":
+					statement = "[_target] call TWC_AI_Control_Gestures_fnc_signalHalt";
+					showDisabled = 1;
+				};
+			};
+		};
+	};
+};

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
 		class ACE_SelfActions {
 			class TWC_Gestures {
 				displayName = "Issue Order";
-				condition = "(canStand _target) && { TWC_Show_Gestures == 1 }";
+				condition = "(canStand _target) && TWC_Show_Gestures";
 				statement = "";
 				exceptions[] = {"isNotSwimming"};
 				showDisabled = 1;

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
@@ -29,4 +29,68 @@ class CfgVehicles {
 			};
 		};
 	};
+	
+	/** MODULES **/
+	class Logic;
+	
+	class Module_Base: Logic {
+		class AttributesBase;
+		class ModuleDescription;
+	};
+
+	class Module_F: Module_Base {
+		class AttributesBase: AttributesBase {
+			class Default;
+			class Edit;
+			class Combo;
+			class CheckBox;
+			class CheckBoxNumber;
+			class ModuleDescription;
+			class Units;
+		};
+		
+		class ModuleDescription: ModuleDescription {
+			class Player;
+		};
+	};
+	
+	//_group getVariable ["TWC_AI_Control_Gestures_HaltIgnoreChance", 0];
+	class TWC_Module_Gestures_SetHaltIgnoreChance: Module_F {
+		author = "[TWC] Bosenator";
+		category = "TWC_AI_Control_Gestures";
+		displayName = "Set Halt Ignore Chance";
+		function = "TWC_AI_Control_Gestures_fnc_moduleSetHaltIgnoreChance";
+		scope = 2;
+		isGlobal = 0;
+		isTriggerActivated = 0;
+		isDisposable = 0;
+		icon = "\twc_ai_control_gestures\ui\haltignorechance_ca.paa";
+		functionPriority = 1;
+		
+		class probability {
+			displayName = "Probability of Ignoring Halt Command(s)";
+			description = "Range, from 0 to 100. Rounded to either.";
+			typeName = "NUMBER";
+			defaultValue = 0;
+		};
+		
+		class ModuleDescription: ModuleDescription {
+			description = "Set Halt Ignore Chance";
+			sync[] = {"AnyAI"};
+		};
+	};
+	
+	//missionNamespace getVariable ["TWC_AI_Control_Gestures_Disabled", false];
+	class TWC_Module_Gestures_SetHaltIgnoreChance: Module_F {
+		author = "[TWC] Bosenator";
+		category = "TWC_AI_Control_Gestures";
+		displayName = "Mission Ignore Gestures";
+		function = "TWC_AI_Control_Gestures_fnc_moduleMissionIgnoreGestures";
+		scope = 2;
+		isGlobal = 0;
+		isTriggerActivated = 0;
+		isDisposable = 0;
+		icon = "\twc_ai_control_gestures\ui\missionignoregestures_ca.paa";
+		functionPriority = 1;
+	};
 };

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
@@ -15,6 +15,7 @@ class CfgVehicles {
 					displayName = "Advance";
 					condition = "true";
 					statement = "[_target] call TWC_AI_Control_Gestures_fnc_signalAdvance";
+					icon = "";
 					showDisabled = 1;
 				};
 				
@@ -22,6 +23,7 @@ class CfgVehicles {
 					displayName = "Halt";
 					condition = "true":
 					statement = "[_target] call TWC_AI_Control_Gestures_fnc_signalHalt";
+					icon = "";
 					showDisabled = 1;
 				};
 			};

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
 		class ACE_SelfActions {
 			class TWC_Gestures {
 				displayName = "Issue Order";
-				condition = "(canStand _target)";
+				condition = "(canStand _target) && { TWC_Show_Gestures == 1 }";
 				statement = "";
 				exceptions[] = {"isNotSwimming"};
 				showDisabled = 1;

--- a/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/CfgVehicles.hpp
@@ -21,7 +21,7 @@ class CfgVehicles {
 				
 				class TWC_AI_Control_Gesture_Halt {
 					displayName = "Halt";
-					condition = "true":
+					condition = "true";
 					statement = "[_target] call TWC_AI_Control_Gestures_fnc_signalHalt";
 					icon = "";
 					showDisabled = 1;

--- a/@twc_framework/addons/twc_ai_control_gestures/config.cpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/config.cpp
@@ -20,6 +20,11 @@ class CfgPatches {
 #include "CfgFunctions.hpp"
 #include "CfgVehicles.hpp"
 
+// Need a client init for CBA Settings.
+// Settings should be:
+// Keybind Advance/Halt Gesture
+// Disable Self-Interaction Menu
+
 class Extended_PostInit_EventHandlers {
 	class TWC_AI_Control_Gestures_InitEH {
 		init = "_this call TWC_AI_Control_Gestures_fnc_init;";

--- a/@twc_framework/addons/twc_ai_control_gestures/config.cpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/config.cpp
@@ -17,6 +17,14 @@ class CfgPatches {
 	};
 };
 
+class CfgFactionClasses {
+	class NO_CATEGORY;
+	
+	class TWC_AI_Control_Gestures: NO_CATEGORY {
+		displayName = "TWC - AI Control Gesture Settings";
+	};
+};
+
 #include "CfgFunctions.hpp"
 #include "CfgVehicles.hpp"
 

--- a/@twc_framework/addons/twc_ai_control_gestures/config.cpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/config.cpp
@@ -20,13 +20,16 @@ class CfgPatches {
 #include "CfgFunctions.hpp"
 #include "CfgVehicles.hpp"
 
-// Need a client init for CBA Settings.
-// Settings should be:
-// Keybind Advance/Halt Gesture
-// Disable Self-Interaction Menu
+class Extended_PreInit_EventHandlers {
+	class TWC_AI_Control_Gestures {
+		init = "_this call TWC_AI_Control_Gestures_fnc_clientPreInit;";
+	};
+};
 
-class Extended_PostInit_EventHandlers {
-	class TWC_AI_Control_Gestures_InitEH {
-		init = "_this call TWC_AI_Control_Gestures_fnc_init;";
+class Extended_InitPost_EventHandlers {
+	class CAManBase {
+		class TWC_AI_Control_Gestures {
+			init = "_this call TWC_AI_Control_Gestures_fnc_init;";
+		};
 	};
 };

--- a/@twc_framework/addons/twc_ai_control_gestures/config.cpp
+++ b/@twc_framework/addons/twc_ai_control_gestures/config.cpp
@@ -1,0 +1,27 @@
+class CfgPatches {
+	class TWC_AI_Control_Gestures {
+		units[]={};
+		weapons[]={};
+		requiredVersion = 1.7;
+
+		requiredAddons[] = {
+			"ace_gestures",
+			"twc_core"
+		};
+
+		author[] = {};
+		authorUrl = "";
+		version = "1";
+		versionStr = "1";
+		versionAr[] = {1};
+	};
+};
+
+#include "CfgFunctions.hpp"
+#include "CfgVehicles.hpp"
+
+class Extended_PostInit_EventHandlers {
+	class TWC_AI_Control_Gestures_InitEH {
+		init = "_this call TWC_AI_Control_Gestures_fnc_init;";
+	};
+};

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_clientPreInit.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_clientPreInit.sqf
@@ -2,7 +2,7 @@
 
 [
 	"TWC",
-	"TWC_AI_Control_Gestures",
+	"TWC_AI_Control_Gestures_Advance",
 	"Advance Signal",
 	{
 		[player] call TWC_AI_Control_Gestures_fnc_signalAdvance;
@@ -20,14 +20,14 @@
 
 [
 	"TWC",
-	"TWC_AI_Control_Gestures",
+	"TWC_AI_Control_Gestures_Halt",
 	"Halt Signal",
 	{
 		[player] call TWC_AI_Control_Gestures_fnc_signalHalt;
 	},
 	"",
 	[
-		DIK_NUMPAD1,
+		DIK_NUMPAD2,
 		[
 			false,
 			false,
@@ -39,7 +39,7 @@
 [
 	"TWC_Show_Gestures",
 	"CHECKBOX",
-	["Show Gestures Menu", "Show the Custom TWC AI Control Gestures Menu under Self-Interaction"],
+	"Show Gestures Menu",
 	"TWC",
 	true,
 	false

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_clientPreInit.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_clientPreInit.sqf
@@ -40,7 +40,16 @@
 	"TWC_Show_Gestures",
 	"CHECKBOX",
 	"Show Gestures Menu",
-	"TWC",
+	["TWC", "AI Control Gestures"],
 	true,
 	false
+] call CBA_fnc_addSetting;
+
+[
+	"TWC_Ignore_Gestures",
+	"CHECKBOX",
+	"AI Ignore Gestures (Server Setting)",
+	["TWC", "AI Control Gestures"],
+	false,
+	true
 ] call CBA_fnc_addSetting;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_clientPreInit.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_clientPreInit.sqf
@@ -1,0 +1,46 @@
+#include "\a3\editor_f\Data\Scripts\dikCodes.h"
+
+[
+	"TWC",
+	"TWC_AI_Control_Gestures",
+	"Advance Signal",
+	{
+		[player] call TWC_AI_Control_Gestures_fnc_signalAdvance;
+	},
+	"",
+	[
+		DIK_NUMPAD1,
+		[
+			false,
+			false,
+			false
+		]
+	]
+] call CBA_fnc_addKeybind;
+
+[
+	"TWC",
+	"TWC_AI_Control_Gestures",
+	"Halt Signal",
+	{
+		[player] call TWC_AI_Control_Gestures_fnc_signalHalt;
+	},
+	"",
+	[
+		DIK_NUMPAD1,
+		[
+			false,
+			false,
+			false
+		]
+	]
+] call CBA_fnc_addKeybind;
+
+[
+	"TWC_Show_Gestures",
+	"CHECKBOX",
+	["Show Gestures Menu", "Show the Custom TWC AI Control Gestures Menu under Self-Interaction"],
+	"TWC",
+	true,
+	false
+] call CBA_fnc_addSetting;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
@@ -1,4 +1,7 @@
-// HC & Server
+// CBA Settings
+// DIK_NUMPAD1
+
+// HC & Server only from now on
 if (!hasInterface) exitWith {};
 
 params ["_thisUnit"];

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
@@ -23,12 +23,16 @@ _fnc_checkNearbyPlayers = {
 ["TWC_AI_Control_Gestures_doHalt", {
 	params ["_group"];
 	
-	_group setVariable ["TWC_AI_Control_Gestures_Halted", true, true];
-	_waypoint = _group addWaypoint [position (leader _group), 0];
-	_waypoint setWaypointType "HOLD";
-	[_group, 0] setWaypointBehaviour "CARELESS";
+	_hasPlayerHaltedThem = _group getVariable ["TWC_AI_Control_Gestures_Halted", false];
 	
-	_group call _fnc_checkNearbyPlayers;
+	if !(_hasPlayerHaltedThem) then {
+		_group setVariable ["TWC_AI_Control_Gestures_Halted", true, true];
+		_waypoint = _group addWaypoint [position (leader _group), 0];
+		_waypoint setWaypointType "HOLD";
+		[_group, 0] setWaypointBehaviour "CARELESS";
+		
+		_group call _fnc_checkNearbyPlayers;
+	};
 }] call CBA_fnc_addEventHandler;
 
 ["TWC_AI_Control_Gestures_doAdvance", {

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
@@ -12,7 +12,7 @@ if (!local _thisUnit) exitWith {};
 _fnc_checkNearbyPlayers = {
 	params ["_group"];
 	
-	if ({_x distance _leader < 50} count allPlayers == 0) then {
+	if ({_x distance (leader _group) < 50} count allPlayers == 0) then {
 		{ _x forceSpeed -1; } forEach (units _group);
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", false, true];
 	} else {

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
@@ -1,0 +1,38 @@
+// HC & Server
+if (!hasInterface) exitWith {};
+
+params ["_thisUnit"];
+
+// Find which one's in control
+if (!local _thisUnit) exitWith {};
+
+/**
+
+Do radi check on _unit.
+For all civilian units/vehicles in radi, act upon;
+
+For halt:
+	- set variable on unit, saying player halted
+	- add hold waypoint at their current location, order 0 (should halt immediately)
+	
+	- check periodically whilst hold, if players are in range
+		- if none are remove hold waypoint and variable, should resume route
+	
+For advance:
+	- check if variable on unit is set
+		- if so, remove waypoint at 0 (should be hold), civ should return to route
+		- nill the variable
+
+**/
+
+["TWC_AI_Control_Gestures_doAdvance", {
+	params ["_unit"];
+	
+	
+}] call CBA_fnc_addEventHandler;
+
+["TWC_AI_Control_Gestures_doHalt", {
+	params ["_unit"];
+	
+	
+}] call CBA_fnc_addEventHandler;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
@@ -1,6 +1,3 @@
-// CBA Settings
-// DIK_NUMPAD1
-
 // HC & Server only from now on
 if (!hasInterface) exitWith {};
 
@@ -13,7 +10,7 @@ _fnc_checkNearbyPlayers = {
 	params ["_group"];
 	
 	if ({_x distance _leader < 150} count allPlayers == 0) then {
-		deleteWaypoint [_group, 0];
+		{ _x forceSpeed -1 } units _group;
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", false, true];
 	} else {
 		[_fnc_checkNearbyPlayers, [_group], 3] call CBA_fnc_waitAndExecute;
@@ -27,9 +24,7 @@ _fnc_checkNearbyPlayers = {
 	
 	if !(_hasPlayerHaltedThem) then {
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", true, true];
-		_waypoint = _group addWaypoint [position (leader _group), 0];
-		_waypoint setWaypointType "HOLD";
-		[_group, 0] setWaypointBehaviour "CARELESS";
+		{ _x forceSpeed 0 } units _group;
 		
 		_group call _fnc_checkNearbyPlayers;
 	};
@@ -41,7 +36,7 @@ _fnc_checkNearbyPlayers = {
 	_hasPlayerHaltedThem = _group getVariable ["TWC_AI_Control_Gestures_Halted", false];
 	
 	if (_hasPlayerHaltedThem) then {
-		deleteWaypoint [_group, 0];
+		{ _x forceSpeed -1 } units _group;
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", false, true];
 	};
 }] call CBA_fnc_addEventHandler;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
@@ -1,6 +1,9 @@
 // HC & Server only from now on
 if (!hasInterface) exitWith {};
 
+// Server ignores it!
+if (TWC_Ignore_Gestures) exitWith {};
+
 _missionIgnoreGestures = missionNamespace getVariable ["TWC_AI_Control_Gestures_Disabled", false];
 if (_missionIgnoreGestures) exitWith {};
 
@@ -8,17 +11,6 @@ params ["_thisUnit"];
 
 // Find which one's in control
 if (!local _thisUnit) exitWith {};
-
-_fnc_checkNearbyPlayers = {
-	params ["_group"];
-	
-	if ({_x distance (leader _group) < 50} count allPlayers == 0) then {
-		{ _x forceSpeed -1; } forEach (units _group);
-		_group setVariable ["TWC_AI_Control_Gestures_Halted", false, true];
-	} else {
-		[_fnc_checkNearbyPlayers, [_group], 3] call CBA_fnc_waitAndExecute;
-	};
-};
 
 ["TWC_AI_Control_Gestures_doHalt", {
 	params ["_group"];
@@ -33,7 +25,7 @@ _fnc_checkNearbyPlayers = {
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", true, true];
 		{ _x forceSpeed 0; } forEach (units _group);
 		
-		_group call _fnc_checkNearbyPlayers;
+		[_group] call TWC_AI_Control_Gestures_fnc_presenceCheckLoop;
 	};
 }] call CBA_fnc_addEventHandler;
 

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_init.sqf
@@ -1,6 +1,9 @@
 // HC & Server only from now on
 if (!hasInterface) exitWith {};
 
+_missionIgnoreGestures = missionNamespace getVariable ["TWC_AI_Control_Gestures_Disabled", false];
+if (_missionIgnoreGestures) exitWith {};
+
 params ["_thisUnit"];
 
 // Find which one's in control
@@ -9,8 +12,8 @@ if (!local _thisUnit) exitWith {};
 _fnc_checkNearbyPlayers = {
 	params ["_group"];
 	
-	if ({_x distance _leader < 150} count allPlayers == 0) then {
-		{ _x forceSpeed -1 } units _group;
+	if ({_x distance _leader < 50} count allPlayers == 0) then {
+		{ _x forceSpeed -1; } forEach (units _group);
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", false, true];
 	} else {
 		[_fnc_checkNearbyPlayers, [_group], 3] call CBA_fnc_waitAndExecute;
@@ -21,10 +24,14 @@ _fnc_checkNearbyPlayers = {
 	params ["_group"];
 	
 	_hasPlayerHaltedThem = _group getVariable ["TWC_AI_Control_Gestures_Halted", false];
+	if (_hasPlayerHaltedThem) exitWith {};
 	
-	if !(_hasPlayerHaltedThem) then {
+	// Special Unit Conditions
+	_probability = _group getVariable ["TWC_AI_Control_Gestures_HaltIgnoreChance", 0];
+	
+	if ((round (random 1) * 100) >= _probability) then {
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", true, true];
-		{ _x forceSpeed 0 } units _group;
+		{ _x forceSpeed 0; } forEach (units _group);
 		
 		_group call _fnc_checkNearbyPlayers;
 	};
@@ -36,7 +43,7 @@ _fnc_checkNearbyPlayers = {
 	_hasPlayerHaltedThem = _group getVariable ["TWC_AI_Control_Gestures_Halted", false];
 	
 	if (_hasPlayerHaltedThem) then {
-		{ _x forceSpeed -1 } units _group;
+		{ _x forceSpeed -1; } forEach (units _group);
 		_group setVariable ["TWC_AI_Control_Gestures_Halted", false, true];
 	};
 }] call CBA_fnc_addEventHandler;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_moduleMissionIgnoreGestures.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_moduleMissionIgnoreGestures.sqf
@@ -1,0 +1,23 @@
+/*
+ * Author: Bosenator
+ * Module function to ignore gestures entirely for this mission.
+ *
+ * Arguments:
+ * 0: The Module Logic <OBJECT>
+ * 1: Synced Objects <ARRAY>
+ * 2: Activated <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+params ["_logic", "_units", "_activated"];
+
+if (!_activated || !isServer) exitWith {};
+
+missionNamespace setVariable ["TWC_AI_Control_Gestures_Disabled", true, true];
+
+if (!isNull _logic) then {
+	deleteVehicle _logic;
+};

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_moduleSetHaltIgnoreChance.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_moduleSetHaltIgnoreChance.sqf
@@ -1,0 +1,28 @@
+/*
+ * Author: Bosenator
+ * Module function to set probability of ignoring halt on unit.
+ *
+ * Arguments:
+ * 0: The Module Logic <OBJECT>
+ * 1: Synced Objects <ARRAY>
+ * 2: Activated <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+ */
+params ["_logic", "_units", "_activated"];
+
+if (!_activated || !isServer) exitWith {};
+
+_probability = _logic getVariable "probability";
+_probability = round ((_probability max 0) min 100);
+
+{
+	(group _x) setVariable ["TWC_AI_Control_Gestures_HaltIgnoreChance", _probability, true];
+} forEach _units;
+
+if (!isNull _logic) then {
+	deleteVehicle _logic;
+};

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_presenceCheckLoop.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_presenceCheckLoop.sqf
@@ -1,0 +1,8 @@
+params ["_group"];
+
+if ({_x distance (leader _group) < 50} count allPlayers == 0) then {
+	{ _x forceSpeed -1; } forEach (units _group);
+	_group setVariable ["TWC_AI_Control_Gestures_Halted", false, true];
+} else {
+	[TWC_AI_Control_Gestures_fnc_presenceCheckLoop, [_group], (3 + (random 2))] call CBA_fnc_waitAndExecute;
+};

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
@@ -2,6 +2,11 @@ params ["_unit"];
 
 if (!local _unit) exitWith {};
 
+_lastTime = _unit getVariable ["TWC_AI_Control_Gestures_Advance_lastTime", 0];
+if ((time - _lastTime) < 2) exitWith {};
+
+_unit setVariable ["TWC_AI_Control_Gestures_Advance_lastTime", time];
+
 // animation
 [_unit, 'gestureFollow'] call ace_common_fnc_doGesture;
 

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
@@ -4,4 +4,22 @@ if (!local _unit) exitWith {};
 
 // animation
 [_unit, selectRandom ['gestureGo','gestureGoB']] call ace_common_fnc_doGesture;
-["TWC_AI_Control_Gestures_doAdvance", [_unit], _unit] call CBA_fnc_targetEvent;
+
+_nearestUnits = _unit nearEntities [["Man", "Car", "Motorcycle"], 100];
+_temp = [];
+
+{
+	if !((group _x) in _temp) then {
+		if (alive _x && side _x == civilian) then {
+			if (vehicle _x == _x) then {
+				["TWC_AI_Control_Gestures_doAdvance", [(group _x)], (leader group _x)] call CBA_fnc_targetEvent;
+			} else {
+				if ({alive _x} count crew (vehicle _x) > 0) then {
+					["TWC_AI_Control_Gestures_doAdvance", [(group _x)], (leader group _x)] call CBA_fnc_targetEvent;
+				};
+			};
+		
+			_temp pushBack (group _x);
+		};
+	};
+} forEach _nearestUnits;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
@@ -3,7 +3,7 @@ params ["_unit"];
 if (!local _unit) exitWith {};
 
 // animation
-[_unit, selectRandom ['gestureGo','gestureGoB']] call ace_common_fnc_doGesture;
+[_unit, 'gestureFollow'] call ace_common_fnc_doGesture;
 
 _nearestUnits = _unit nearEntities [["Man", "Car", "Motorcycle"], 40];
 _temp = [];

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
@@ -5,7 +5,7 @@ if (!local _unit) exitWith {};
 // animation
 [_unit, selectRandom ['gestureGo','gestureGoB']] call ace_common_fnc_doGesture;
 
-_nearestUnits = _unit nearEntities [["Man", "Car", "Motorcycle"], 100];
+_nearestUnits = _unit nearEntities [["Man", "Car", "Motorcycle"], 40];
 _temp = [];
 
 {

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalAdvance.sqf
@@ -1,0 +1,7 @@
+params ["_unit"];
+
+if (!local _unit) exitWith {};
+
+// animation
+[_unit, selectRandom ['gestureGo','gestureGoB']] call ace_common_fnc_doGesture;
+["TWC_AI_Control_Gestures_doAdvance", [_unit], _unit] call CBA_fnc_targetEvent;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
@@ -2,6 +2,11 @@ params ["_unit"];
 
 if (!local _unit) exitWith {};
 
+_lastTime = _unit getVariable ["TWC_AI_Control_Gestures_Halt_lastTime", 0];
+if ((time - _lastTime) < 2) exitWith {};
+
+_unit setVariable ["TWC_AI_Control_Gestures_Halt_lastTime", time];
+
 // animation
 [_unit, "gestureFreeze"] call ace_common_fnc_doGesture;
 

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
@@ -1,0 +1,7 @@
+params ["_unit"];
+
+if (!local _unit) exitWith {};
+
+// animation
+[_unit, "gestureFreeze"] call ace_common_fnc_doGesture;
+["TWC_AI_Control_Gestures_doHalt", [_unit], _unit] call CBA_fnc_targetEvent;

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
@@ -5,7 +5,7 @@ if (!local _unit) exitWith {};
 // animation
 [_unit, "gestureFreeze"] call ace_common_fnc_doGesture;
 
-_nearestUnits = _unit nearEntities [["Man", "Car", "Motorcycle"], 100];
+_nearestUnits = _unit nearEntities [["Man", "Car", "Motorcycle"], 40];
 _temp = [];
 
 {

--- a/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
+++ b/@twc_framework/addons/twc_ai_control_gestures/functions/fn_signalHalt.sqf
@@ -4,4 +4,22 @@ if (!local _unit) exitWith {};
 
 // animation
 [_unit, "gestureFreeze"] call ace_common_fnc_doGesture;
-["TWC_AI_Control_Gestures_doHalt", [_unit], _unit] call CBA_fnc_targetEvent;
+
+_nearestUnits = _unit nearEntities [["Man", "Car", "Motorcycle"], 100];
+_temp = [];
+
+{
+	if !((group _x) in _temp) then {
+		if (alive _x && side _x == civilian) then {
+			if (vehicle _x == _x) then {
+				["TWC_AI_Control_Gestures_doHalt", [(group _x)], (leader group _x)] call CBA_fnc_targetEvent;
+			} else {
+				if ({alive _x} count crew (vehicle _x) > 0) then {
+					["TWC_AI_Control_Gestures_doHalt", [(group _x)], (leader group _x)] call CBA_fnc_targetEvent;
+				};
+			};
+		
+			_temp pushBack (group _x);
+		};
+	};
+} forEach _nearestUnits;

--- a/prep_all_mods.cmd
+++ b/prep_all_mods.cmd
@@ -14,7 +14,7 @@ for /d %%i in (*) do (
 		cd !tmp!
 		for /d %%a in (*) do (
 			echo Pboing %%a
-			makePbo !tmp!\%%a
+			makePbo -ABU -X "thumbs.db,*.txt,*.h,*.dep,*.cpp,*.bak,*.png,*.log,*.pew,source" -Z=default -@=%%a !tmp!\%%a
 		)
 	)
 )

--- a/prep_config_compatibility.cmd
+++ b/prep_config_compatibility.cmd
@@ -13,7 +13,7 @@ for /d %%i in (*) do (
 		cd !tmp!
 		for /d %%a in (*) do (
 			echo Pboing %%a
-			makePbo !tmp!\%%a
+			makePbo -ABU -X "thumbs.db,*.txt,*.h,*.dep,*.cpp,*.bak,*.png,*.log,*.pew,source" -Z=default -@=%%a !tmp!\%%a
 		)
 	)
 )

--- a/prep_framework.cmd
+++ b/prep_framework.cmd
@@ -13,7 +13,7 @@ for /d %%i in (*) do (
 		cd !tmp!
 		for /d %%a in (*) do (
 			echo Pboing %%a
-			makePbo !tmp!\%%a
+			makePbo -ABU -X "thumbs.db,*.txt,*.h,*.dep,*.cpp,*.bak,*.png,*.log,*.pew,source" -Z=default -@=%%a !tmp!\%%a
 		)
 	)
 )

--- a/prep_public.cmd
+++ b/prep_public.cmd
@@ -13,7 +13,7 @@ for /d %%i in (*) do (
 		cd !tmp!
 		for /d %%a in (*) do (
 			echo Pboing %%a
-			makePbo !tmp!\%%a
+			makePbo -ABU -X "thumbs.db,*.txt,*.h,*.dep,*.cpp,*.bak,*.png,*.log,*.pew,source" -Z=default -@=%%a !tmp!\%%a
 		)
 	)
 )


### PR DESCRIPTION
As mentioned in #208 

Adds:
- Keybindable functionality to halt, and allow civilians to progress
- Civilians will resume when everyone moves far away enough
- Module to set an ignore chance for the civilian group (for example, having a stubbon individual or a suicide bomber)
- Module to disable gestures on the mission
- Settings to disable the self-interaction menu, or gestures on the server entirely

Planned future expansions:
- Hands up command (would work well with a search function, and a chance for them to pull a gun instead module thing)
- Get out order for vehicles (again, in conjunctio n with a search function)