### PR TITLE
PLAN Mag change

### DIFF
--- a/@twc_config/addons/twc_opfor_plan/units.hpp
+++ b/@twc_config/addons/twc_opfor_plan/units.hpp
@@ -119,12 +119,12 @@ class TWC_Infantry_PLAN_Regular_MG: TWC_Infantry_PLAN_Regular_Rifleman
 	};
 	magazines[] =
 	{
-		MAG_2("VME_200Rnd_DPB10"),
+		MAG_2("VME_QJY88_200Rnd_DBP10"),
 		MAG_2("SmokeShell")
 	};
 	respawnmagazines[] =
 	{
-		MAG_2("VME_200Rnd_DPB10"),
+		MAG_2("VME_QJY88_200Rnd_DBP10"),
 		MAG_2("SmokeShell")
 	};
 };


### PR DESCRIPTION
Wrong ammo classname, changed it to the correct one.

**This pull request will:**
- Change the class name of the magazine for the MG due to the following error.
![20190830172032_1](https://user-images.githubusercontent.com/20481634/64032807-85d7aa00-cb4b-11e9-9335-c87b3deb6f58.jpg)

