### PR TITLE
Post Op Fixes

### DIFF
--- a/@twc_config/addons/twc_incorporeal/CfgDeathScreens.hpp
+++ b/@twc_config/addons/twc_incorporeal/CfgDeathScreens.hpp
@@ -46,6 +46,11 @@ class CfgDeathScreens {
 		text = "was turned into a colander";
 	};
 	
+	class broadcast_mode: instant_death {
+		sound = "twc_broadcast_mode";
+		fadeOut = 95;
+	};
+	
 	class overdose {
 		text = "died via overdose";
 		sound = "twc_overdose";

--- a/@twc_config_compatibility/addons/twc_gearFixes/CfgAmmo.hpp
+++ b/@twc_config_compatibility/addons/twc_gearFixes/CfgAmmo.hpp
@@ -205,6 +205,7 @@ class CfgAmmo {
 			hitWater = "ImpactEffectsWater";
 		};
 	};
+	
 	class B_762x51_Ball: BulletBase {
 		class CamShakePlayerFire {
 			distance = 1;
@@ -212,27 +213,8 @@ class CfgAmmo {
 			frequency = 10;
 			power = 5;
 		};
+		
 		ACE_muzzleVelocityVariationSD = 1;
-		class HitEffects {
-			Hit_Foliage_green = "ImpactLeavesGreen";
-			Hit_Foliage_Dead = "ImpactLeavesDead";
-			Hit_Foliage_Green_big = "ImpactLeavesGreenBig";
-			Hit_Foliage_Palm = "ImpactLeavesPalm";
-			Hit_Foliage_Pine = "ImpactLeavesPine";
-			hitFoliage = "ImpactLeaves";
-			hitGlass = "ImpactGlass";
-			hitGlassArmored = "twc_762_hiteffect_grey";
-			hitWood = "twc_762_hiteffect_grey";
-			hitMetal = "twc_762_hiteffect_grey";
-			hitMetalPlate = "twc_762_hiteffect_grey";
-			hitBuilding = "twc_762_hiteffect_grey";
-			hitPlastic = "twc_762_hiteffect_grey";
-			hitRubber = "twc_762_hiteffect_grey";
-			hitConcrete = "twc_762_hiteffect_grey";
-			hitGroundSoft = "twc_762_hiteffect_grey";
-			hitGroundHard = "twc_762_hiteffect_grey";
-			hitWater = "ImpactEffectsWater";
-		};
 	};
 	
 	class B_556x45_Ball:BulletBase {

--- a/@twc_config_compatibility/addons/twc_gearFixes/qol.hpp
+++ b/@twc_config_compatibility/addons/twc_gearFixes/qol.hpp
@@ -324,33 +324,6 @@ class twc_127_hiteffect_grey
    };
 };
 
-class twc_762_hiteffect_grey
-{
-	class smoke
-	{
-       simulation = "particles";   //type of simulation - particles or light
-       type = "twc_ImpactSmoke_762";           //name of PE's class defined in CfgCloudlets or light's class defined in CfgLights
-       position[] = {0, 0, 0};     //position related to the default position or memorypoint
-       lifeTime = 0.1;            //life time of emitter
-       qualityLevel = -1;          // effect is only used when the the particle quality option particlesQuality in user settings matches this qualityLevel. -1 play everytime, 0 play only on low, 1 play only on normal, 2 play only on high. Default: -1
-       start = 1;                  //is used only if the lifeTime parameter is defined, if value is changed from negative to positive then the effect is triggered
-       enabled = 1;                //1 effect is enabled, -1 effect is disabled
-	   intensity = 1;
-   };
-	class puff
-	{
-       simulation = "particles";   //type of simulation - particles or light
-       type = "ImpactConcrete";           //name of PE's class defined in CfgCloudlets or light's class defined in CfgLights
-       position[] = {0, 0, 0};     //position related to the default position or memorypoint
-       lifeTime = 1.3;            //life time of emitter
-       qualityLevel = -1;          // effect is only used when the the particle quality option particlesQuality in user settings matches this qualityLevel. -1 play everytime, 0 play only on low, 1 play only on normal, 2 play only on high. Default: -1
-       start = 1;                  //is used only if the lifeTime parameter is defined, if value is changed from negative to positive then the effect is triggered
-       enabled = 1;                //1 effect is enabled, -1 effect is disabled
-	   intensity = 1;
-   };
-};
-
-
 class GrenadeExplosion
 {
 	class GrenadeExp1
@@ -410,14 +383,5 @@ class cfgcloudlets
 		moveVelocity[] = {0, 0, 0};
 		rotationVelocity = 0;
 		color[] = {{0.9,0.9,0.9,0.18},{0.9,0.9,0.9,0.06},{0.9,0.9,0.9,0.012},{0.9,0.9,0.9,0.001}};
-	};
-	
-	class ImpactDustConcrete2;
-	class twc_impactsmoke_762: ImpactDustConcrete2
-	{
-		size[] = {0.8,1.1,1.4};
-		position[] = {0,0,0};
-		color[] = {{0.9,0.9,0.9,0.48},{0.9,0.9,0.9,0.26},{0.9,0.9,0.9,0.12},{0.9,0.9,0.9,0.001}};
-		moveVelocity[] = {"0","0","1.2*directionZ"};
 	};
 };

--- a/@twc_config_public/addons/twc_pubfixes/CfgAmmo.hpp
+++ b/@twc_config_public/addons/twc_pubfixes/CfgAmmo.hpp
@@ -149,6 +149,7 @@ class CfgAmmo {
 			hitWater = "ImpactEffectsWater";
 		};
 	};
+	
 	class B_762x51_Ball: BulletBase {
 		class CamShakePlayerFire {
 			distance = 1;
@@ -156,27 +157,8 @@ class CfgAmmo {
 			frequency = 10;
 			power = 5;
 		};
+		
 		ACE_muzzleVelocityVariationSD = 1;
-		class HitEffects {
-			Hit_Foliage_green = "ImpactLeavesGreen";
-			Hit_Foliage_Dead = "ImpactLeavesDead";
-			Hit_Foliage_Green_big = "ImpactLeavesGreenBig";
-			Hit_Foliage_Palm = "ImpactLeavesPalm";
-			Hit_Foliage_Pine = "ImpactLeavesPine";
-			hitFoliage = "ImpactLeaves";
-			hitGlass = "ImpactGlass";
-			hitGlassArmored = "twc_762_hiteffect_grey";
-			hitWood = "twc_762_hiteffect_grey";
-			hitMetal = "twc_762_hiteffect_grey";
-			hitMetalPlate = "twc_762_hiteffect_grey";
-			hitBuilding = "twc_762_hiteffect_grey";
-			hitPlastic = "twc_762_hiteffect_grey";
-			hitRubber = "twc_762_hiteffect_grey";
-			hitConcrete = "twc_762_hiteffect_grey";
-			hitGroundSoft = "twc_762_hiteffect_grey";
-			hitGroundHard = "twc_762_hiteffect_grey";
-			hitWater = "ImpactEffectsWater";
-		};
 	};
 	
 	class B_556x45_Ball;

--- a/@twc_framework/addons/twc_core/functions/fn_clientPostInit.sqf
+++ b/@twc_framework/addons/twc_core/functions/fn_clientPostInit.sqf
@@ -86,7 +86,7 @@ if !((goggles player) in approvedFacewear) then {
 	removeGoggles player;
 };
 
-[{ getClientStateNumber > 9 || !(isMultiplayer)}, {
+[{ time > 0 }, {
 	/** Reconnect spot? **/
 	if (!isNil "ForwardBasePos" && !(player getVariable ["twc_ignoreForwardBase", false])) then {
 		player setPos ForwardBasePos;


### PR DESCRIPTION
Remove fault code that produces the following, in attempt to address Crash to Desktop issues:
```19:49:15 Error during evaluation of expression _moveVelocity in twc_impactsmoke_762```

Change reference from ClientState to time based for map removal. 