### PR TITLE
Make rotary more confusing

### DIFF
--- a/operation_preparation/Rolesheets/Modern/Attachments/rotary_wing_aircraft.txt
+++ b/operation_preparation/Rolesheets/Modern/Attachments/rotary_wing_aircraft.txt
@@ -10,18 +10,18 @@ Pilot (T): [color=#ccccff]No-One[/color]
 FAC (T): [color=#ccccff]No-One[/color]
 [color=#ff9933]Pilot (T): [color=#ccccff]No-One[/color]
 
-[u][color=#ffffff]AH.1 Wildcat Reconnaissance Aircraft[/color][/u]
+[u][color=#ffffff]Wildcat AH1 Reconnaissance Aircraft[/color][/u]
 [color=#ff9933]System Operator[/color] (T): [color=#ccccff]No-One[/color]
 Pilot (T): [color=#ccccff]No-One[/color]
 
-[u][color=#ffffff]AH.1 Wildcat Anti-Tank Aircraft[/color][/u]
+[u][color=#ffffff]Wildcat AH1 Anti-Tank Aircraft[/color][/u]
 [color=#ff9933]System Operator[/color] (T): [color=#ccccff]No-One[/color]
 Pilot (T): [color=#ccccff]No-One[/color]
 
-[u][color=#ffffff]AH.1 Wildcat Attack Aircraft[/color][/u]
+[u][color=#ffffff]Wildcat AH1 Attack Aircraft[/color][/u]
 FAC (T): [color=#ccccff]No-One[/color]
 [color=#ff9933]Pilot (T): [color=#ccccff]No-One[/color]
 
-[u][color=#ffffff]AH.7 Apache Attack Aircraft[/color][/u]
+[u][color=#ffffff]Apache AH1 Attack Aircraft[/color][/u]
 [color=#ff9933]System Operator[/color] (T): [color=#ccccff]No-One[/color]
 Pilot (T): [color=#ccccff]No-One[/color]


### PR DESCRIPTION
**This pull request will:**
- Change naming scheme to real army naming scheme (layout/ punctuation changes)
- Rename Apache as AH1 (too) Ah7 was lynx