### PR TITLE
Launcher Resupply

### DIFF
--- a/@twc_config/addons/twc_ammoboxes/crates_launchers.hpp
+++ b/@twc_config/addons/twc_ammoboxes/crates_launchers.hpp
@@ -85,6 +85,7 @@ class TWC_AmmoBox_Launchers_NLAW_Portable: TWC_AmmoBox_Launcher_Portable {
 	
 	class TransportWeapons {
 		ADD_WEAP(launch_NLAW_F, 2);
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 };
 

--- a/@twc_config/addons/twc_vehicles/modern/modern_tracked.hpp
+++ b/@twc_config/addons/twc_vehicles/modern/modern_tracked.hpp
@@ -41,6 +41,7 @@ class TWC_Vehicle_Modern_Warrior_Woodland: TWC_Vehicle_FV510_W_SLAT {
 	
 	class TransportWeapons {
 		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 
 	class TransportBackpacks { };
@@ -89,7 +90,7 @@ class TWC_Vehicle_Modern_Warrior_COIN_Woodland: TWC_Vehicle_FV510_W_SLAT {
 	};
 	
 	class TransportWeapons {
-		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 
 	class TransportBackpacks { };
@@ -136,6 +137,7 @@ class TWC_Vehicle_Modern_Warrior_Desert: TWC_Vehicle_FV510_D_SLAT {
 	
 	class TransportWeapons {
 		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 
 	class TransportBackpacks { };
@@ -184,7 +186,7 @@ class TWC_Vehicle_Modern_Warrior_COIN_Desert: TWC_Vehicle_FV510_D_SLAT {
 	};
 	
 	class TransportWeapons {
-		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 
 	class TransportBackpacks { };
@@ -237,6 +239,7 @@ class TWC_Vehicle_Modern_Bulldog_Desert: UK3CB_BAF_FV432_Mk3_GPMG_Sand {
 	
 	class TransportWeapons {
 		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 
 	class TransportBackpacks { };
@@ -290,7 +293,7 @@ class TWC_Vehicle_Modern_Bulldog_COIN_Desert: UK3CB_BAF_FV432_Mk3_GPMG_Sand {
 	};
 	
 	class TransportWeapons {
-		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 
 	class TransportBackpacks { };
@@ -343,6 +346,7 @@ class TWC_Vehicle_Modern_Bulldog_Woodland: UK3CB_BAF_FV432_Mk3_GPMG_Green {
 	
 	class TransportWeapons {
 		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 
 	class TransportBackpacks { };
@@ -396,7 +400,7 @@ class TWC_Vehicle_Modern_Bulldog_COIN_Woodland: UK3CB_BAF_FV432_Mk3_GPMG_Green {
 	};
 	
 	class TransportWeapons {
-		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 
 	class TransportBackpacks { };

--- a/@twc_config/addons/twc_vehicles/modern/modern_wheeled.hpp
+++ b/@twc_config/addons/twc_vehicles/modern/modern_wheeled.hpp
@@ -42,8 +42,9 @@ class TWC_Vehicle_Modern_LandRover_Woodland: TWC_BaseClass_LR_Soft_Base_F {
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons {
-		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
 	};
 
 	class TransportBackpacks { };
@@ -83,7 +84,10 @@ class TWC_Vehicle_Modern_LandRover_Desert: TWC_Vehicle_Modern_LandRover_Woodland
 		"",
 		"\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_base_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_hardtop_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_special_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\flag_unionJack.paa"
 	};
-	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 	class AnimationSources: AnimationSources {
 		class Mudguards_Hide: Mudguards_Hide {
 			initPhase = 1;
@@ -136,7 +140,9 @@ class TWC_Vehicle_Modern_LandRover_Woodland_COIN: TWC_BaseClass_LR_Soft_Base_F {
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons { 
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -174,7 +180,9 @@ class TWC_Vehicle_Modern_LandRover_Desert_COIN: TWC_Vehicle_Modern_LandRover_Woo
 		"",
 		"\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_base_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_hardtop_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_special_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\flag_unionJack.paa"
 	};
-	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class AnimationSources: AnimationSources {
 		class Mudguards_Hide: Mudguards_Hide {
 			initPhase = 0;
@@ -224,8 +232,9 @@ class TWC_Vehicle_Modern_LandRoverHard_Woodland: TWC_BaseClass_LR_Hard_Base_F {
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons {
-		ADD_WEAP(launch_NLAW_F, ADD_QNTY(MODERN_NLAW));
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
 	};
 
 	class TransportBackpacks { };
@@ -265,7 +274,9 @@ class TWC_Vehicle_Modern_LandRoverHard_Desert: TWC_Vehicle_Modern_LandRoverHard_
 		"",
 		"\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_base_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_hardtop_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_special_baf_sand_co.paa","\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\flag_unionJack.paa"
 	};
-	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class AnimationSources: AnimationSources {
 		class Mudguards_Hide: Mudguards_Hide {
 			initPhase = 1;
@@ -318,7 +329,10 @@ class TWC_Vehicle_Modern_LandRoverHard_Woodland_COIN: TWC_Vehicle_Modern_LandRov
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -359,7 +373,9 @@ class TWC_Vehicle_Modern_LandRoverHard_Desert_COIN: TWC_Vehicle_Modern_LandRover
 		"\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\lr_special_baf_sand_co.paa",
 		"\uk3cb_baf_vehicles\addons\uk3cb_baf_vehicles_landrover\data\flag_unionJack.paa"
 	};
-	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class AnimationSources: AnimationSources {
 		class Mudguards_Hide: Mudguards_Hide {
 			initPhase = 0;
@@ -412,7 +428,9 @@ class TWC_Vehicle_Modern_LandRoverSnatch_Desert_COIN: TWC_BaseClass_LR_Snatch_Ba
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -498,7 +516,10 @@ class TWC_Vehicle_Modern_Mastiff_HMG_Woodland: CUP_B_Mastiff_HMG_GB_W {
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 2);
+	};
 	class TransportBackpacks { };
 };
 
@@ -529,6 +550,10 @@ class TWC_Vehicle_Modern_Mastiff_HMG_Woodland_COIN: TWC_Vehicle_Modern_Mastiff_H
 		
 		ADD_MAGA(SmokeShell, ADD_QNTY(SECTION_SMOKE));
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 };
 
@@ -575,7 +600,10 @@ class TWC_Vehicle_Modern_Mastiff_HMG_Desert: CUP_B_Mastiff_HMG_GB_D {
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 2);
+	};
 	class TransportBackpacks { };
 };
 
@@ -606,6 +634,10 @@ class TWC_Vehicle_Modern_Mastiff_HMG_Desert_COIN: TWC_Vehicle_Modern_Mastiff_HMG
 		
 		ADD_MAGA(SmokeShell, ADD_QNTY(SECTION_SMOKE));
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 };
 
@@ -652,7 +684,10 @@ class TWC_Vehicle_Modern_Mastiff_GMG_Woodland: CUP_B_Mastiff_GMG_GB_W {
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 2);
+	};
 	class TransportBackpacks { };
 };
 
@@ -683,6 +718,10 @@ class TWC_Vehicle_Modern_Mastiff_GMG_Woodland_COIN: TWC_Vehicle_Modern_Mastiff_G
 		
 		ADD_MAGA(SmokeShell, ADD_QNTY(SECTION_SMOKE));
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 };
 
@@ -729,7 +768,10 @@ class TWC_Vehicle_Modern_Mastiff_GMG_Desert: CUP_B_Mastiff_GMG_GB_D {
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 2);
+	};
 	class TransportBackpacks { };
 };
 
@@ -760,6 +802,10 @@ class TWC_Vehicle_Modern_Mastiff_GMG_Desert_COIN: TWC_Vehicle_Modern_Mastiff_GMG
 		
 		ADD_MAGA(SmokeShell, ADD_QNTY(SECTION_SMOKE));
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 2);
 	};
 };
 
@@ -814,7 +860,9 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GMG_Woodland_COIN: TWC_BaseClass_LR_WMIK_
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -869,6 +917,10 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GMG_Woodland: TWC_Vehicle_Modern_LandRove
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_GMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GMG));
 	};
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 };
 
 class TWC_Vehicle_Modern_LandRoverWMIK_GMG_Desert_COIN: TWC_BaseClass_LR_WMIK_GMG_Sand_F {
@@ -920,7 +972,9 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GMG_Desert_COIN: TWC_BaseClass_LR_WMIK_GM
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -975,6 +1029,10 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GMG_Desert: TWC_Vehicle_Modern_LandRoverW
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_GMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GMG));
 	};
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 };
 
 class TWC_Vehicle_Modern_LandRoverWMIK_GPMG_Woodland_COIN: TWC_BaseClass_LR_WMIK_GPMG_Green_F {
@@ -1025,7 +1083,9 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GPMG_Woodland_COIN: TWC_BaseClass_LR_WMIK
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -1079,6 +1139,10 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GPMG_Woodland: TWC_Vehicle_Modern_LandRov
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_GPMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
 	};
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 };
 
 class TWC_Vehicle_Modern_LandRoverWMIK_GPMG_Desert_COIN: TWC_BaseClass_LR_WMIK_GPMG_Sand_F {
@@ -1129,7 +1193,9 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GPMG_Desert_COIN: TWC_BaseClass_LR_WMIK_G
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -1183,6 +1249,10 @@ class TWC_Vehicle_Modern_LandRoverWMIK_GPMG_Desert: TWC_Vehicle_Modern_LandRover
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_GPMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
 	};
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 };
 
 class TWC_Vehicle_Modern_LandRoverWMIK_HMG_Desert_COIN: TWC_BaseClass_LR_WMIK_HMG_Sand_F {
@@ -1234,7 +1304,9 @@ class TWC_Vehicle_Modern_LandRoverWMIK_HMG_Desert_COIN: TWC_BaseClass_LR_WMIK_HM
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_HMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -1289,6 +1361,11 @@ class TWC_Vehicle_Modern_LandRoverWMIK_HMG_Desert: TWC_Vehicle_Modern_LandRoverW
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_HMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_HMG));
 	};
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
+	
 };
 
 class TWC_Vehicle_Modern_LandRoverWMIK_HMG_Woodland_COIN: TWC_BaseClass_LR_WMIK_HMG_Green_F {
@@ -1340,7 +1417,9 @@ class TWC_Vehicle_Modern_LandRoverWMIK_HMG_Woodland_COIN: TWC_BaseClass_LR_WMIK_
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_HMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+	};
 	class TransportBackpacks { };
 	
 	class AnimationSources: AnimationSources {
@@ -1395,6 +1474,10 @@ class TWC_Vehicle_Modern_LandRoverWMIK_HMG_Woodland: TWC_Vehicle_Modern_LandRove
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_HMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_HMG));
 	};
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 };
 
 #undef CURRENT_VEHICLE
@@ -1445,7 +1528,10 @@ class TWC_Vehicle_Modern_Husky_GPMG_Desert: UK3CB_BAF_Husky_Passenger_GPMG_Sand 
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 	class TransportBackpacks { };
 };
 
@@ -1480,6 +1566,10 @@ class TWC_Vehicle_Modern_Husky_GPMG_Desert_COIN: TWC_Vehicle_Modern_Husky_GPMG_D
 		
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_GPMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 };
 
@@ -1529,7 +1619,10 @@ class TWC_Vehicle_Modern_Husky_GPMG_Woodland: UK3CB_BAF_Husky_Passenger_GPMG_Gre
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons {
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 	class TransportBackpacks { };
 };
 
@@ -1564,6 +1657,10 @@ class TWC_Vehicle_Modern_Husky_GPMG_Woodland_COIN: TWC_Vehicle_Modern_Husky_GPMG
 		
 		ADD_MAGA(UK3CB_BAF_762_200Rnd_T, ADD_QNTY(MODERN_GPMG));
 		ADD_MAGA(UK3CB_BAF_762_200Rnd, ADD_QNTY(MODERN_GPMG));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 };
 
@@ -1612,7 +1709,10 @@ class TWC_Vehicle_Modern_Husky_GMG_Desert: UK3CB_BAF_Husky_Passenger_GMG_Sand {
 		ADD_MAGA(UK3CB_BAF_32Rnd_40mm_G_Box, ADD_QNTY(MODERN_GMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons { 
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 2);
+	};
 	class TransportBackpacks { };
 };
 
@@ -1646,6 +1746,10 @@ class TWC_Vehicle_Modern_Husky_GMG_Desert_COIN: TWC_Vehicle_Modern_Husky_GMG_Des
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 		
 		ADD_MAGA(UK3CB_BAF_32Rnd_40mm_G_Box, ADD_QNTY(MODERN_GMG));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 };
 
@@ -1694,7 +1798,10 @@ class TWC_Vehicle_Modern_Husky_GMG_Woodland: UK3CB_BAF_Husky_Passenger_GMG_Green
 		ADD_MAGA(UK3CB_BAF_32Rnd_40mm_G_Box, ADD_QNTY(MODERN_GMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons { 
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 	class TransportBackpacks { };
 };
 
@@ -1728,6 +1835,10 @@ class TWC_Vehicle_Modern_Husky_GMG_Woodland_COIN: TWC_Vehicle_Modern_Husky_GMG_W
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 		
 		ADD_MAGA(UK3CB_BAF_32Rnd_40mm_G_Box, ADD_QNTY(MODERN_GMG));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 };
 
@@ -1776,7 +1887,10 @@ class TWC_Vehicle_Modern_Husky_HMG_Desert: UK3CB_BAF_Husky_Passenger_HMG_Sand {
 		ADD_MAGA(UK3CB_BAF_127_100Rnd, ADD_QNTY(MODERN_HMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons { 
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 	class TransportBackpacks { };
 };
 
@@ -1810,6 +1924,10 @@ class TWC_Vehicle_Modern_Husky_HMG_Desert_COIN: TWC_Vehicle_Modern_Husky_HMG_Des
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 		
 		ADD_MAGA(UK3CB_BAF_127_100Rnd, ADD_QNTY(MODERN_HMG));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 };
 
@@ -1858,7 +1976,10 @@ class TWC_Vehicle_Modern_Husky_HMG_Woodland: UK3CB_BAF_Husky_Passenger_HMG_Green
 		ADD_MAGA(UK3CB_BAF_127_100Rnd, ADD_QNTY(MODERN_HMG));
 	};
 	
-	class TransportWeapons { };
+	class TransportWeapons { 
+		ADD_WEAP(CUP_launch_M72A6, 1);
+		ADD_WEAP(launch_NLAW_F, 1);
+	};
 	class TransportBackpacks { };
 };
 
@@ -1892,5 +2013,9 @@ class TWC_Vehicle_Modern_Husky_HMG_Woodland_COIN: TWC_Vehicle_Modern_Husky_HMG_W
 		ADD_MAGA(CUP_HandGrenade_L109A2_HE, ADD_QNTY(SECTION_GRENADE));
 		
 		ADD_MAGA(UK3CB_BAF_127_100Rnd, ADD_QNTY(MODERN_HMG));
+	};
+	
+	class TransportWeapons {  
+		ADD_WEAP(CUP_launch_M72A6, 1);
 	};
 };


### PR DESCRIPTION
**This pull request will:**
Add 1 x LASM to Nlaw crate to allow for resupply. Currently we very rarely get lasm resupply. adding 1 to the nlaw crate will allow the nlaw crate to be equivalent to the at capabilities at mission start.
Add lasms and nlaws to all infantry ground vehicles according to coin or conventional variant and vehicle size.