### PR TITLE
+ acre_api_fnc_filterUnitLoadout

### DIFF
--- a/@twc_framework/addons/twc_framework/disconnectgear/fn_disconnectgear.sqf
+++ b/@twc_framework/addons/twc_framework/disconnectgear/fn_disconnectgear.sqf
@@ -25,6 +25,7 @@ if (!hasInterface) exitWith {};
 
 
 //As is tradion we do an ugly sleep
+// -- can hook into CBA_loadingScreen event or "twc_framework_initComplete", it'll be more reliable/performant
 [] spawn {
 	waitUntil {sleep 1; time > 0 && name player != "No Vehicle" && !(isnil "TWC_MissionStart") };
 	twc_op_newStart = false;

--- a/@twc_framework/addons/twc_framework/disconnectgear/fn_findoldgear.sqf
+++ b/@twc_framework/addons/twc_framework/disconnectgear/fn_findoldgear.sqf
@@ -48,6 +48,10 @@ if(str _loadout != "false")then{
 		_itemList = _itemList + (itemCargo _x);
 		deleteVehicle _x;
 	}forEach _nearHolders;
+	
+	// apply acre fix to ID generated radios
+	_loadout = [_loadout] call acre_api_fnc_filterUnitLoadout;
+	
 	//finally set the loadout
 	player setUnitLoadout _loadout;
 
@@ -86,7 +90,10 @@ if(str _loadout != "false")then{
 	//Plan B Use ProfileNamespace on no body found
 	_loadout = ProfileNamespace getVariable ["twc_framework_disconnectGear",false];
 	if(str _loadout != "false")then{
+		// apply acre fix to ID generated radios
+		_loadout = [_loadout] call acre_api_fnc_filterUnitLoadout;
 		player setUnitLoadout _loadout;
+		
 		ProfileNamespace setVariable ["twc_framework_disconnectGear", _loadout];
 		saveProfileNamespace;
 		//Earplug check


### PR DESCRIPTION
Adds acre_api_fnc_filterUnitLoadout to reconnecting players, to make sure radios will work correctly for those that disconnect & reconnect.